### PR TITLE
paypal.me link als zusätzliches user-feld

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
-# Kurzbeschreibung der Änderungen
+## Kurzbeschreibung der Änderungen
 
 //TODO
 
-# Bestätigung:
+## Bestätigung:
 
 - [ ] @peter-mueller 
 - [ ] @FabianWilms 
 
-# Referenzen
+## Referenzen
 
 closes #
 dependes on #

--- a/user/adapter/command/command.go
+++ b/user/adapter/command/command.go
@@ -3,6 +3,7 @@ package command
 import (
 	"github.com/WeisswurstSystems/WWM-BB/user/usecase/activate"
 	"github.com/WeisswurstSystems/WWM-BB/user/usecase/register"
+	"github.com/WeisswurstSystems/WWM-BB/user/usecase/setUpPayPal"
 	"github.com/WeisswurstSystems/WWM-BB/wwm"
 	"net/http"
 )
@@ -10,6 +11,7 @@ import (
 type Interactor interface {
 	register.RegisterUseCase
 	activate.ActivateUseCase
+	setUpPayPal.SetUpPayPalUseCase
 }
 
 type CommandHandler struct {
@@ -23,6 +25,15 @@ func (ch *CommandHandler) Register(w http.ResponseWriter, req *http.Request) err
 		return err
 	}
 	return ch.Interactor.Register(e)
+}
+
+func (ch *CommandHandler) SetUpPayPal(w http.ResponseWriter, req *http.Request) error {
+	var e setUpPayPal.Request
+	err := wwm.DecodeBody(req.Body, &e)
+	if err != nil {
+		return err
+	}
+	return ch.Interactor.SetUpPayPal(e)
 }
 
 func (ch *CommandHandler) Activate(w http.ResponseWriter, req *http.Request) error {

--- a/user/payment.go
+++ b/user/payment.go
@@ -1,0 +1,5 @@
+package user
+
+type PayPal struct {
+	MeLink string `json:"meLink"`
+}

--- a/user/usecase/register/register.go
+++ b/user/usecase/register/register.go
@@ -18,10 +18,10 @@ type Interactor struct {
 }
 
 type Request struct {
-	Mail        string `json:"mail"`
-	Password    string `json:"password"`
-	PaypalLink	string `json:"paypalLink"`
-	MailEnabled bool   `json:"mailEnabled"`
+	Mail        string      `json:"mail"`
+	Password    string      `json:"password"`
+	PayPal      user.PayPal `json:"payPal"`
+	MailEnabled bool        `json:"mailEnabled"`
 }
 
 func (i Interactor) Register(req Request) error {
@@ -56,7 +56,7 @@ func buildUser(req Request) user.User {
 	uid := util.GetUID(60)
 	return user.User{
 		Login:          user.Login{req.Mail, req.Password},
-		PaypalLink:		req.PaypalLink,
+		PayPal:         req.PayPal,
 		RegistrationID: uid,
 		Roles:          []string{"user"},
 		MailEnabled:    req.MailEnabled,

--- a/user/usecase/register/register.go
+++ b/user/usecase/register/register.go
@@ -20,6 +20,7 @@ type Interactor struct {
 type Request struct {
 	Mail        string `json:"mail"`
 	Password    string `json:"password"`
+	PaypalLink	string `json:"paypalLink"`
 	MailEnabled bool   `json:"mailEnabled"`
 }
 
@@ -55,6 +56,7 @@ func buildUser(req Request) user.User {
 	uid := util.GetUID(60)
 	return user.User{
 		Login:          user.Login{req.Mail, req.Password},
+		PaypalLink:		req.PaypalLink,
 		RegistrationID: uid,
 		Roles:          []string{"user"},
 		MailEnabled:    req.MailEnabled,

--- a/user/usecase/register/register.go
+++ b/user/usecase/register/register.go
@@ -18,10 +18,9 @@ type Interactor struct {
 }
 
 type Request struct {
-	Mail        string      `json:"mail"`
-	Password    string      `json:"password"`
-	PayPal      user.PayPal `json:"payPal"`
-	MailEnabled bool        `json:"mailEnabled"`
+	Mail        string `json:"mail"`
+	Password    string `json:"password"`
+	MailEnabled bool   `json:"mailEnabled"`
 }
 
 func (i Interactor) Register(req Request) error {
@@ -56,7 +55,6 @@ func buildUser(req Request) user.User {
 	uid := util.GetUID(60)
 	return user.User{
 		Login:          user.Login{req.Mail, req.Password},
-		PayPal:         req.PayPal,
 		RegistrationID: uid,
 		Roles:          []string{"user"},
 		MailEnabled:    req.MailEnabled,

--- a/user/usecase/setUpPayPal/setUpPayPal.go
+++ b/user/usecase/setUpPayPal/setUpPayPal.go
@@ -1,0 +1,36 @@
+package setUpPayPal
+
+import (
+	"github.com/WeisswurstSystems/WWM-BB/user"
+	"github.com/WeisswurstSystems/WWM-BB/user/usecase"
+	"github.com/WeisswurstSystems/WWM-BB/user/usecase/authenticate"
+)
+
+type SetUpPayPalUseCase interface {
+	Register(Request) error
+}
+type Interactor struct {
+	user.Store
+	authenticate.AuthenticateUseCase
+}
+
+type Request struct {
+	PayPal user.PayPal `json:"payPal"`
+	Login  user.Login  `json:"login"`
+}
+
+func (i Interactor) SetUpPayPal(req Request) error {
+	u, err := i.AuthenticateUseCase.Authenticate(req.Login)
+	if err != nil {
+		return err
+	}
+
+	u.PayPal = req.PayPal
+
+	err = i.Save(user)
+	if err != nil {
+		return err
+	}
+	usecase.LOG.Printf("did %v", req)
+	return nil
+}

--- a/user/usecase/setUpPayPal/setUpPayPal.go
+++ b/user/usecase/setUpPayPal/setUpPayPal.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SetUpPayPalUseCase interface {
-	Register(Request) error
+	SetUpPayPal(Request) error
 }
 type Interactor struct {
 	user.Store
@@ -27,7 +27,7 @@ func (i Interactor) SetUpPayPal(req Request) error {
 
 	u.PayPal = req.PayPal
 
-	err = i.Save(user)
+	err = i.Save(u)
 	if err != nil {
 		return err
 	}

--- a/user/user.go
+++ b/user/user.go
@@ -11,6 +11,7 @@ type Login struct {
 }
 type User struct {
 	Login          `json:"login"`
+	PaypalLink string `json:"paypalLink"`
 	RegistrationID string         `json:"registrationID"`
 	Roles          []string       `json:"roles"`
 	DefaultOrders  map[string]int `json:"defaultOrders"`

--- a/user/user.go
+++ b/user/user.go
@@ -11,7 +11,7 @@ type Login struct {
 }
 type User struct {
 	Login          `json:"login"`
-	PaypalLink string `json:"paypalLink"`
+	PayPal         PayPal         `json:"payPal"`
 	RegistrationID string         `json:"registrationID"`
 	Roles          []string       `json:"roles"`
 	DefaultOrders  map[string]int `json:"defaultOrders"`

--- a/wwm/construction/user.go
+++ b/wwm/construction/user.go
@@ -8,6 +8,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/user/usecase/activate"
 	"github.com/WeisswurstSystems/WWM-BB/user/usecase/authenticate"
 	"github.com/WeisswurstSystems/WWM-BB/user/usecase/register"
+	"github.com/WeisswurstSystems/WWM-BB/user/usecase/setUpPayPal"
 )
 
 var UserStore = driver.NewMongoStore()
@@ -18,6 +19,7 @@ var UserUseCases = struct {
 	authenticate.AuthenticateUseCase
 	activate.ActivateUseCase
 	register.RegisterUseCase
+	setUpPayPal.SetUpPayPalUseCase
 }{
 	AuthenticateUseCase: authenticate.Interactor{
 		ReadStore: UserStore,

--- a/wwm/construction/user_routing.go
+++ b/wwm/construction/user_routing.go
@@ -11,4 +11,5 @@ func AddUserRoutes(r *mux.Router) {
 	do := r.PathPrefix("/do").Subrouter()
 	do.Handle("/register", wwm.Handler(UserCommand.Register)).Methods("POST")
 	do.Handle("/activate", wwm.Handler(UserCommand.Activate)).Methods("POST")
+	do.Handle("/setUpPayPal", wwm.Handler(UserCommand.SetUpPayPal)).Methods("POST")
 }


### PR DESCRIPTION
# Kurzbeschreibung der Änderungen

Es kann ein paypal.me Link zu den User-Infos gespeichert werden.
Die Frage ist was wir speichern wollen. Die Links sehen immer so aus:

https://www.paypal.me/EinVomNutzerKonfigurierterName/Geldbetrag

Also als funktionierendes Beispiel:

https://www.paypal.me/FabianWilms/5,32

Ich würde jetzt sagen wir speichern `https://www.paypal.me/EinVomNutzerKonfigurierterName` und packen zusätzlich im Issue #28 bei der Bestellung des abrufenden Nutzers den Link des Meeting-Besitzers oder des Käufers mit dem Geldbetrag rein.

# Bestätigung:

- [ ] @peter-mueller 
- [x] @FabianWilms 

# Referenzen

closes #26