### PR TITLE
#28 gesamtkosten und item berechnung

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,16 @@
 ## Kurzbeschreibung der Änderungen
 
-//TODO
+//TODO Kurze Beschreibung
+
+## Checkliste
+
+- [ ] Funktionalität getestet
+- [ ] Dokumentation im Wiki ergänzt (bitte hier Änderung(en) verlinken)
 
 ## Bestätigung:
 
-- [ ] @peter-mueller 
-- [ ] @FabianWilms 
+- [ ] @
 
 ## Referenzen
 
-closes #
-dependes on #
-only after #
+closes #x

--- a/meeting/adapter/query/query.go
+++ b/meeting/adapter/query/query.go
@@ -6,11 +6,12 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/gorilla/mux"
 	"net/http"
-	"github.com/WeisswurstSystems/WWM-BB/wwm/construction"
+	"github.com/WeisswurstSystems/WWM-BB/user"
 )
 
 type QueryHandler struct {
 	MeetingStore meeting.ReadStore
+	UserStore user.ReadStore
 }
 
 func (ch *QueryHandler) FindAll(w http.ResponseWriter, req *http.Request) error {
@@ -38,7 +39,7 @@ func (ch *QueryHandler) FindByID(w http.ResponseWriter, req *http.Request) error
 		return err
 	}
 
-	creatorUser, err := construction.UserQuery.FindByMail(result.Creator)
+	creatorUser, err := ch.UserStore.FindByMail(result.Creator)
 
 	if (err != nil) {
 		errors.New("Creator wurde nicht in Nutzer-DB gefunden")

--- a/meeting/adapter/query/query.go
+++ b/meeting/adapter/query/query.go
@@ -2,16 +2,17 @@ package query
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/WeisswurstSystems/WWM-BB/meeting"
+	"github.com/WeisswurstSystems/WWM-BB/user"
 	"github.com/go-errors/errors"
 	"github.com/gorilla/mux"
-	"net/http"
-	"github.com/WeisswurstSystems/WWM-BB/user"
 )
 
 type QueryHandler struct {
 	MeetingStore meeting.ReadStore
-	UserStore user.ReadStore
+	UserStore    user.ReadStore
 }
 
 func (ch *QueryHandler) FindAll(w http.ResponseWriter, req *http.Request) error {
@@ -41,11 +42,11 @@ func (ch *QueryHandler) FindByID(w http.ResponseWriter, req *http.Request) error
 
 	creatorUser, err := ch.UserStore.FindByMail(result.Creator)
 
-	if (err != nil) {
+	if err != nil {
 		errors.New("Creator wurde nicht in Nutzer-DB gefunden")
 	}
 
-	detailedResult := meeting.ToDetailedMeeting(result, creatorUser.PayPal.MeLink)
+	detailedResult := result.Detailed(creatorUser.PayPal.MeLink)
 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")

--- a/meeting/detailed.go
+++ b/meeting/detailed.go
@@ -1,0 +1,106 @@
+package meeting
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/WeisswurstSystems/WWM-BB/util"
+)
+
+type DetailedMeeting struct {
+	ID         MeetingID       `json:"id"`
+	Place      string          `json:"place"`
+	Creator    string          `json:"creator"`
+	Buyer      string          `json:"buyer"`
+	Date       time.Time       `json:"date"`
+	CloseDate  time.Time       `json:"closeDate"`
+	Closed     bool            `json:"closed"`
+	Orders     []DetailedOrder `json:"orders"`
+	Offer      Offer           `json:"offer"`
+	TotalPrice float64         `json:"totalPrice"`
+	TotalItems []OrderItem     `json:"totalItems"`
+}
+
+type DetailedOrder struct {
+	Customer   string      `json:"customer"`
+	Payed      bool        `json:"payed"`
+	Items      []OrderItem `json:"items"`
+	TotalPrice float64     `json:"totalPrice"`
+	PayLink    string      `json:"payLink"`
+}
+
+func (m Meeting) Detailed(paypalLink string) DetailedMeeting {
+	detailedMeeting := DetailedMeeting{
+		ID:        m.ID,
+		Place:     m.Place,
+		Creator:   m.Creator,
+		Buyer:     m.Buyer,
+		Date:      m.Date,
+		CloseDate: m.CloseDate,
+		Closed:    m.Closed,
+		Orders:    ToDetailedOrders(m.Orders, m.Offer, paypalLink),
+		Offer:     m.Offer,
+	}
+
+	var totalPrice float64
+	var totalItems []OrderItem
+
+	for _, order := range detailedMeeting.Orders {
+		totalPrice += order.TotalPrice
+		for _, item := range order.Items {
+			index := util.IndexOf(len(totalItems), func(i int) bool {
+				return totalItems[i].ItemName == item.ItemName
+			})
+			if index == -1 {
+				totalItems = append(totalItems, OrderItem{
+					ItemName: item.ItemName,
+					Amount:   item.Amount,
+				})
+			} else {
+				totalItems[index].Amount = totalItems[index].Amount + item.Amount
+			}
+		}
+	}
+
+	detailedMeeting.TotalPrice = totalPrice
+	detailedMeeting.TotalItems = totalItems
+
+	return detailedMeeting
+}
+
+func ToDetailedOrders(orders []Order, products []Product, payPalLink string) []DetailedOrder {
+	var detailedOrders []DetailedOrder
+	for _, order := range orders {
+		detailedOrders = append(detailedOrders, order.Detailed(products, payPalLink))
+	}
+	return detailedOrders
+}
+
+func (order Order) Detailed(products []Product, paypalLink string) DetailedOrder {
+	var detailedOrder = DetailedOrder{
+		Customer: order.Customer,
+		Payed:    order.Payed,
+		Items:    order.Items,
+	}
+
+	var resultPrice float64
+
+	for _, item := range detailedOrder.Items {
+		price := products[util.IndexOf(len(products), func(i int) bool {
+			return products[i].Name == item.ItemName
+		})].Price
+		resultPrice += (float64(item.Amount) * price)
+	}
+
+	detailedOrder.TotalPrice = util.FloatToFixed(resultPrice, 2)
+
+	if paypalLink != "" {
+		if !strings.HasSuffix(paypalLink, "/") {
+			paypalLink += "/"
+		}
+		detailedOrder.PayLink = paypalLink + strconv.FormatFloat(float64(detailedOrder.TotalPrice), 'f', 2, 32)
+	}
+
+	return detailedOrder
+}

--- a/meeting/detailed_test.go
+++ b/meeting/detailed_test.go
@@ -1,10 +1,11 @@
 package meeting
 
 import (
-	"github.com/WeisswurstSystems/WWM-BB/user"
-	"testing"
-	"github.com/stretchr/testify/assert"
 	"strconv"
+	"testing"
+
+	"github.com/WeisswurstSystems/WWM-BB/user"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToDetailedMeeting(t *testing.T) {
@@ -17,12 +18,12 @@ func TestToDetailedMeeting(t *testing.T) {
 		Product{"Weißbier", 2.50}}
 
 	testOrders := []Order{
-		{Customer:"A", Items: []OrderItem{{"Brezen", 2}, {"Weißbier", 1}}},
-		{Customer:"B", Items: []OrderItem{{"Weisswurst", 1}, {"Brezen", 1}, {"Weißbier", 0}}},
-		{Customer:"C", Items: []OrderItem{{"Weisswurst", 6}}},
-		{Customer:"D", Items: []OrderItem{{"Weißbier", 2}}},
-		{Customer:"E", Items: []OrderItem{{"Brezen", 5}}},
-		}
+		{Customer: "A", Items: []OrderItem{{"Brezen", 2}, {"Weißbier", 1}}},
+		{Customer: "B", Items: []OrderItem{{"Weisswurst", 1}, {"Brezen", 1}, {"Weißbier", 0}}},
+		{Customer: "C", Items: []OrderItem{{"Weisswurst", 6}}},
+		{Customer: "D", Items: []OrderItem{{"Weißbier", 2}}},
+		{Customer: "E", Items: []OrderItem{{"Brezen", 5}}},
+	}
 
 	testMeeting := Meeting{
 		Creator: uLogin.Mail,
@@ -30,13 +31,13 @@ func TestToDetailedMeeting(t *testing.T) {
 		Orders:  testOrders,
 	}
 
-	resultMeeting := ToDetailedMeeting(testMeeting, testUser.PayPal.MeLink)
+	resultMeeting := testMeeting.Detailed(testUser.PayPal.MeLink)
 
 	for _, order := range resultMeeting.Orders {
 
 		if order.Customer == "A" {
-			assert.Equal(t, order.TotalPrice,5.1, "")
-			assert.Equal(t, order.PayLink, uPaypal.MeLink + strconv.FormatFloat(float64(order.TotalPrice), 'f', 2, 32))
+			assert.Equal(t, order.TotalPrice, 5.1, "")
+			assert.Equal(t, order.PayLink, uPaypal.MeLink+strconv.FormatFloat(float64(order.TotalPrice), 'f', 2, 32))
 		} else if order.Customer == "B" {
 			assert.Equal(t, order.TotalPrice, 1.95, "")
 		} else if order.Customer == "C" {
@@ -49,5 +50,5 @@ func TestToDetailedMeeting(t *testing.T) {
 			t.Fatalf("No Customer is named %v", order.Customer)
 		}
 	}
-	assert.Equal(t, resultMeeting.TotalPrice,22.45, "")
+	assert.Equal(t, resultMeeting.TotalPrice, 22.45, "")
 }

--- a/meeting/meeting.go
+++ b/meeting/meeting.go
@@ -31,7 +31,7 @@ type DetailedMeeting struct {
 	Closed     bool            `json:"closed"`
 	Orders     []DetailedOrder `json:"orders"`
 	Offer      Offer           `json:"offer"`
-	TotalPrice float32         `json:"totalPrice"`
+	TotalPrice float64         `json:"totalPrice"`
 	TotalItems []OrderItem     `json:"totalItems"`
 }
 
@@ -74,11 +74,11 @@ func ToDetailedMeeting(m Meeting, paypalLink string) DetailedMeeting {
 		Offer:     m.Offer,
 	}
 
-	var totalPrice float32
+	var totalPrice float64
 	var totalItems []OrderItem
 
 	for _, order := range detailedMeeting.Orders {
-		totalPrice += totalPrice + order.TotalPrice
+		totalPrice += order.TotalPrice
 		for _, item := range order.Items {
 			index := util.IndexOf(len(totalItems), func(i int) bool {
 				return totalItems[i].ItemName == item.ItemName

--- a/meeting/meeting.go
+++ b/meeting/meeting.go
@@ -96,6 +96,8 @@ func ToDetailedMeeting(m Meeting, paypalLink string) DetailedMeeting {
 
 	detailedMeeting.TotalPrice = totalPrice
 	detailedMeeting.TotalItems = totalItems
+
+	return detailedMeeting
 }
 
 type ReadStore interface {

--- a/meeting/meeting.go
+++ b/meeting/meeting.go
@@ -4,6 +4,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/wwm"
 	"net/http"
 	"time"
+	"github.com/WeisswurstSystems/WWM-BB/util"
 )
 
 type MeetingID string
@@ -18,6 +19,20 @@ type Meeting struct {
 	Closed    bool      `json:"closed"`
 	Orders    []Order   `json:"orders"`
 	Offer     Offer     `json:"offer"`
+}
+
+type DetailedMeeting struct {
+	ID         MeetingID       `json:"id"`
+	Place      string          `json:"place"`
+	Creator    string          `json:"creator"`
+	Buyer      string          `json:"buyer"`
+	Date       time.Time       `json:"date"`
+	CloseDate  time.Time       `json:"closeDate"`
+	Closed     bool            `json:"closed"`
+	Orders     []DetailedOrder `json:"orders"`
+	Offer      Offer           `json:"offer"`
+	TotalPrice float32         `json:"totalPrice"`
+	TotalItems []OrderItem     `json:"totalItems"`
 }
 
 type ReducedMeeting struct {
@@ -44,6 +59,43 @@ func AllReduced(meetings []Meeting) []ReducedMeeting {
 		list = append(list, v.Reduced())
 	}
 	return list
+}
+
+func ToDetailedMeeting(m Meeting, paypalLink string) DetailedMeeting {
+	detailedMeeting := DetailedMeeting{
+		ID:        m.ID,
+		Place:     m.Place,
+		Creator:   m.Creator,
+		Buyer:     m.Buyer,
+		Date:      m.Date,
+		CloseDate: m.CloseDate,
+		Closed:    m.Closed,
+		Orders:    ToDetailedOrders(m.Orders, m.Offer, paypalLink),
+		Offer:     m.Offer,
+	}
+
+	var totalPrice float32
+	var totalItems []OrderItem
+
+	for _, order := range detailedMeeting.Orders {
+		totalPrice += totalPrice + order.TotalPrice
+		for _, item := range order.Items {
+			index := util.IndexOf(len(totalItems), func(i int) bool {
+				return totalItems[i].ItemName == item.ItemName
+			})
+			if index == -1 {
+				totalItems = append(totalItems, OrderItem{
+					ItemName: item.ItemName,
+					Amount: item.Amount,
+				})
+			} else {
+				totalItems[index].Amount = totalItems[index].Amount + item.Amount
+			}
+		}
+	}
+
+	detailedMeeting.TotalPrice = totalPrice
+	detailedMeeting.TotalItems = totalItems
 }
 
 type ReadStore interface {

--- a/meeting/meeting.go
+++ b/meeting/meeting.go
@@ -1,10 +1,10 @@
 package meeting
 
 import (
-	"github.com/WeisswurstSystems/WWM-BB/wwm"
 	"net/http"
 	"time"
-	"github.com/WeisswurstSystems/WWM-BB/util"
+
+	"github.com/WeisswurstSystems/WWM-BB/wwm"
 )
 
 type MeetingID string
@@ -19,85 +19,6 @@ type Meeting struct {
 	Closed    bool      `json:"closed"`
 	Orders    []Order   `json:"orders"`
 	Offer     Offer     `json:"offer"`
-}
-
-type DetailedMeeting struct {
-	ID         MeetingID       `json:"id"`
-	Place      string          `json:"place"`
-	Creator    string          `json:"creator"`
-	Buyer      string          `json:"buyer"`
-	Date       time.Time       `json:"date"`
-	CloseDate  time.Time       `json:"closeDate"`
-	Closed     bool            `json:"closed"`
-	Orders     []DetailedOrder `json:"orders"`
-	Offer      Offer           `json:"offer"`
-	TotalPrice float64         `json:"totalPrice"`
-	TotalItems []OrderItem     `json:"totalItems"`
-}
-
-type ReducedMeeting struct {
-	ID        MeetingID `json:"id"`
-	Place     string    `json:"place"`
-	Date      time.Time `json:"date"`
-	CloseDate time.Time `json:"closeDate"`
-	Closed    bool      `json:"closed"`
-}
-
-func (m Meeting) Reduced() ReducedMeeting {
-	return ReducedMeeting{
-		ID:        m.ID,
-		Place:     m.Place,
-		Date:      m.Date,
-		CloseDate: m.CloseDate,
-		Closed:    m.Closed,
-	}
-}
-
-func AllReduced(meetings []Meeting) []ReducedMeeting {
-	list := make([]ReducedMeeting, 0, len(meetings))
-	for _, v := range meetings {
-		list = append(list, v.Reduced())
-	}
-	return list
-}
-
-func ToDetailedMeeting(m Meeting, paypalLink string) DetailedMeeting {
-	detailedMeeting := DetailedMeeting{
-		ID:        m.ID,
-		Place:     m.Place,
-		Creator:   m.Creator,
-		Buyer:     m.Buyer,
-		Date:      m.Date,
-		CloseDate: m.CloseDate,
-		Closed:    m.Closed,
-		Orders:    ToDetailedOrders(m.Orders, m.Offer, paypalLink),
-		Offer:     m.Offer,
-	}
-
-	var totalPrice float64
-	var totalItems []OrderItem
-
-	for _, order := range detailedMeeting.Orders {
-		totalPrice += order.TotalPrice
-		for _, item := range order.Items {
-			index := util.IndexOf(len(totalItems), func(i int) bool {
-				return totalItems[i].ItemName == item.ItemName
-			})
-			if index == -1 {
-				totalItems = append(totalItems, OrderItem{
-					ItemName: item.ItemName,
-					Amount: item.Amount,
-				})
-			} else {
-				totalItems[index].Amount = totalItems[index].Amount + item.Amount
-			}
-		}
-	}
-
-	detailedMeeting.TotalPrice = totalPrice
-	detailedMeeting.TotalItems = totalItems
-
-	return detailedMeeting
 }
 
 type ReadStore interface {

--- a/meeting/order.go
+++ b/meeting/order.go
@@ -1,11 +1,5 @@
 package meeting
 
-import (
-	"github.com/WeisswurstSystems/WWM-BB/util"
-	"strconv"
-	"strings"
-)
-
 type OrderItem struct {
 	ItemName ProductName `json:"itemName"`
 	Amount   int         `json:"amount"`
@@ -16,49 +10,3 @@ type Order struct {
 	Payed    bool        `json:"payed"`
 	Items    []OrderItem `json:"items"`
 }
-
-type DetailedOrder struct {
-	Customer   string      `json:"customer"`
-	Payed      bool        `json:"payed"`
-	Items      []OrderItem `json:"items"`
-	TotalPrice float64     `json:"totalPrice"`
-	PayLink    string      `json:"payLink"`
-}
-
-func ToDetailedOrders(orders []Order, products []Product, payPalLink string) []DetailedOrder {
-	var detailedOrders []DetailedOrder
-	for _, order := range orders {
-		detailedOrders = append(detailedOrders, ToDetailedOrder(order, products, payPalLink))
-	}
-	return detailedOrders
-}
-
-func ToDetailedOrder(order Order, products []Product, paypalLink string) DetailedOrder {
-	var detailedOrder = DetailedOrder{
-		Customer: order.Customer,
-		Payed:    order.Payed,
-		Items:    order.Items,
-	}
-
-	var resultPrice float64
-
-	for _, item := range detailedOrder.Items {
-		price := products[
-			util.IndexOf(len(products), func(i int) bool {
-				return products[i].Name == item.ItemName
-			})].Price
-		resultPrice += (float64(item.Amount) * price)
-	}
-
-	detailedOrder.TotalPrice = util.FloatToFixed(resultPrice, 2)
-
-	if paypalLink != "" {
-		if !strings.HasSuffix(paypalLink, "/") {
-			paypalLink += "/"
-		}
-		detailedOrder.PayLink = paypalLink +  strconv.FormatFloat(float64(detailedOrder.TotalPrice), 'f', 2, 32)
-	}
-
-	return detailedOrder
-}
-

--- a/meeting/order.go
+++ b/meeting/order.go
@@ -1,12 +1,59 @@
 package meeting
 
+import (
+	"github.com/WeisswurstSystems/WWM-BB/util"
+	"strconv"
+)
+
 type OrderItem struct {
-	ItemName string `json:"itemName"`
-	Amount   int    `json:"amount"`
+	ItemName ProductName `json:"itemName"`
+	Amount   int         `json:"amount"`
 }
 
 type Order struct {
 	Customer string      `json:"customer"`
 	Payed    bool        `json:"payed"`
 	Items    []OrderItem `json:"items"`
+}
+
+type DetailedOrder struct {
+	Customer   string      `json:"customer"`
+	Payed      bool        `json:"payed"`
+	Items      []OrderItem `json:"items"`
+	TotalPrice float32     `json:"totalPrice"`
+	PayLink    string      `json:"payLink"`
+}
+
+func ToDetailedOrders(orders []Order, products []Product, payPalLink string) []DetailedOrder {
+	var detailedOrders []DetailedOrder
+	for _, order := range orders {
+		detailedOrders = append(detailedOrders, ToDetailedOrder(order, products, payPalLink))
+	}
+	return detailedOrders
+}
+
+func ToDetailedOrder(order Order, products []Product, paypalLink string) DetailedOrder {
+	var detailedOrder = DetailedOrder{
+		Customer: order.Customer,
+		Payed:    order.Payed,
+		Items:    order.Items,
+	}
+
+	var resultPrice float32
+
+	for _, item := range detailedOrder.Items {
+		price := products[
+			util.IndexOf(len(products), func(i int) bool {
+				return products[i].Name == item.ItemName
+			})].Price
+		resultPrice += resultPrice + (float32(item.Amount) * price)
+	}
+
+	detailedOrder.TotalPrice = resultPrice
+
+	if paypalLink != "" {
+		detailedOrder.PayLink = paypalLink + "/" + strconv.FormatFloat(float64(detailedOrder.TotalPrice), 'f', 2, 32)
+	}
+
+	return detailedOrder
 }

--- a/meeting/order.go
+++ b/meeting/order.go
@@ -3,6 +3,7 @@ package meeting
 import (
 	"github.com/WeisswurstSystems/WWM-BB/util"
 	"strconv"
+	"strings"
 )
 
 type OrderItem struct {
@@ -20,7 +21,7 @@ type DetailedOrder struct {
 	Customer   string      `json:"customer"`
 	Payed      bool        `json:"payed"`
 	Items      []OrderItem `json:"items"`
-	TotalPrice float32     `json:"totalPrice"`
+	TotalPrice float64     `json:"totalPrice"`
 	PayLink    string      `json:"payLink"`
 }
 
@@ -39,21 +40,25 @@ func ToDetailedOrder(order Order, products []Product, paypalLink string) Detaile
 		Items:    order.Items,
 	}
 
-	var resultPrice float32
+	var resultPrice float64
 
 	for _, item := range detailedOrder.Items {
 		price := products[
 			util.IndexOf(len(products), func(i int) bool {
 				return products[i].Name == item.ItemName
 			})].Price
-		resultPrice += resultPrice + (float32(item.Amount) * price)
+		resultPrice += (float64(item.Amount) * price)
 	}
 
-	detailedOrder.TotalPrice = resultPrice
+	detailedOrder.TotalPrice = util.FloatToFixed(resultPrice, 2)
 
 	if paypalLink != "" {
-		detailedOrder.PayLink = paypalLink + "/" + strconv.FormatFloat(float64(detailedOrder.TotalPrice), 'f', 2, 32)
+		if !strings.HasSuffix(paypalLink, "/") {
+			paypalLink += "/"
+		}
+		detailedOrder.PayLink = paypalLink +  strconv.FormatFloat(float64(detailedOrder.TotalPrice), 'f', 2, 32)
 	}
 
 	return detailedOrder
 }
+

--- a/meeting/product.go
+++ b/meeting/product.go
@@ -5,7 +5,7 @@ type ProductName string
 
 type Product struct {
 	Name  ProductName `json:"name"`
-	Price float32     `json:"price"`
+	Price float64     `json:"price"`
 }
 
 func (o Offer) Put(p Product) Offer {

--- a/meeting/reduced.go
+++ b/meeting/reduced.go
@@ -1,0 +1,29 @@
+package meeting
+
+import "time"
+
+type ReducedMeeting struct {
+	ID        MeetingID `json:"id"`
+	Place     string    `json:"place"`
+	Date      time.Time `json:"date"`
+	CloseDate time.Time `json:"closeDate"`
+	Closed    bool      `json:"closed"`
+}
+
+func (m Meeting) Reduced() ReducedMeeting {
+	return ReducedMeeting{
+		ID:        m.ID,
+		Place:     m.Place,
+		Date:      m.Date,
+		CloseDate: m.CloseDate,
+		Closed:    m.Closed,
+	}
+}
+
+func AllReduced(meetings []Meeting) []ReducedMeeting {
+	list := make([]ReducedMeeting, 0, len(meetings))
+	for _, v := range meetings {
+		list = append(list, v.Reduced())
+	}
+	return list
+}

--- a/meeting/toDetailedMeeting_test.go
+++ b/meeting/toDetailedMeeting_test.go
@@ -1,0 +1,53 @@
+package meeting
+
+import (
+	"github.com/WeisswurstSystems/WWM-BB/user"
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+)
+
+func TestToDetailedMeeting(t *testing.T) {
+	uLogin := user.Login{Mail: "hans@test.de"}
+	uPaypal := user.PayPal{"https://paypal.me/hanstest/"}
+	testUser := user.User{Login: uLogin, PayPal: uPaypal, Roles: []string{"admin"}}
+
+	testOffer := Offer{Product{"Weisswurst", 0.65},
+		Product{"Brezen", 1.30},
+		Product{"Weißbier", 2.50}}
+
+	testOrders := []Order{
+		{Customer:"A", Items: []OrderItem{{"Brezen", 2}, {"Weißbier", 1}}},
+		{Customer:"B", Items: []OrderItem{{"Weisswurst", 1}, {"Brezen", 1}, {"Weißbier", 0}}},
+		{Customer:"C", Items: []OrderItem{{"Weisswurst", 6}}},
+		{Customer:"D", Items: []OrderItem{{"Weißbier", 2}}},
+		{Customer:"E", Items: []OrderItem{{"Brezen", 5}}},
+		}
+
+	testMeeting := Meeting{
+		Creator: uLogin.Mail,
+		Offer:   testOffer,
+		Orders:  testOrders,
+	}
+
+	resultMeeting := ToDetailedMeeting(testMeeting, testUser.PayPal.MeLink)
+
+	for _, order := range resultMeeting.Orders {
+
+		if order.Customer == "A" {
+			assert.Equal(t, order.TotalPrice,5.1, "")
+			assert.Equal(t, order.PayLink, uPaypal.MeLink + strconv.FormatFloat(float64(order.TotalPrice), 'f', 2, 32))
+		} else if order.Customer == "B" {
+			assert.Equal(t, order.TotalPrice, 1.95, "")
+		} else if order.Customer == "C" {
+			assert.Equal(t, order.TotalPrice, 3.9, "")
+		} else if order.Customer == "D" {
+			assert.Equal(t, order.TotalPrice, 5.0, "")
+		} else if order.Customer == "E" {
+			assert.Equal(t, order.TotalPrice, 6.5, "")
+		} else {
+			t.Fatalf("No Customer is named %v", order.Customer)
+		}
+	}
+	assert.Equal(t, resultMeeting.TotalPrice,22.45, "")
+}

--- a/util/float.go
+++ b/util/float.go
@@ -1,0 +1,12 @@
+package util
+
+import "math"
+
+func round(num float64) int {
+	return int(num + math.Copysign(0.5, num))
+}
+
+func FloatToFixed(num float64, precision int) float64 {
+	output := math.Pow(10, float64(precision))
+	return float64(round(num * output)) / output
+}

--- a/util/sliceUtils.go
+++ b/util/sliceUtils.go
@@ -9,7 +9,7 @@ func Contains(s []string, e string) bool {
 	return false
 }
 
-func SliceIndex(limit int, predicate func(i int) bool) int {
+func IndexOf(limit int, predicate func(i int) bool) int {
 	for i := 0; i < limit; i++ {
 		if predicate(i) {
 			return i

--- a/wwm/construction/meeting.go
+++ b/wwm/construction/meeting.go
@@ -33,6 +33,8 @@ var MeetingUseCases = struct {
 var MeetingCommand = command.CommandHandler{
 	Interactor: &MeetingUseCases,
 }
+
 var MeetingQuery = query.QueryHandler{
 	MeetingStore: MeetingStore,
+	UserStore: UserStore,
 }


### PR DESCRIPTION
## Kurzbeschreibung der Änderungen

Es werden die Gesamtkosten der einzelnen Bestellungen, sowie die Gesamtkosten und Gesamtitem-Zahl des Meetings berechnet, wenn ein Meeting im Detail abgefragt wird.

## Checkliste

- [x] Funktionalität getestet
- [x] Dokumentation im Wiki ergänzt https://github.com/WeisswurstSystems/WWM-BB/wiki/Schnittstellen#meeting-detail

## Bestätigung:

- [ ] @peter-mueller 

## Referenzen

closes #28 