### PR TITLE
resolve Order als bezahlt markieren

### DIFF
--- a/meeting/adapter/command/command.go
+++ b/meeting/adapter/command/command.go
@@ -9,6 +9,10 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setplace"
 	"github.com/WeisswurstSystems/WWM-BB/wwm"
 	"net/http"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/payorder"
+	"github.com/gorilla/mux"
+	"github.com/go-errors/errors"
+	"github.com/WeisswurstSystems/WWM-BB/meeting"
 )
 
 type Interactor interface {
@@ -18,6 +22,7 @@ type Interactor interface {
 	removeproduct.RemoveProductUseCase
 	setbuyer.SetBuyerUseCase
 	setplace.SetPlaceUseCase
+	payorder.PayOrderUsecase
 }
 
 type CommandHandler struct {
@@ -81,4 +86,21 @@ func (ch *CommandHandler) SetPlace(w http.ResponseWriter, req *http.Request) err
 		return err
 	}
 	return ch.Interactor.SetPlace(e)
+}
+
+func (ch *CommandHandler) PayOrder(w http.ResponseWriter, req *http.Request) error {
+	var e payorder.Request
+	e.Login.Mail, e.Login.Password, _  = req.BasicAuth()
+
+	id, ok := mux.Vars(req)["meetingId"]
+	if !ok {
+		return errors.New("meeting id url parameter missing")
+	}
+	e.MeetingID = meeting.MeetingID(id)
+
+	err := wwm.DecodeBody(req.Body, &e)
+	if err != nil {
+		return err
+	}
+	return ch.Interactor.PayOrder(e)
 }

--- a/meeting/adapter/command/command.go
+++ b/meeting/adapter/command/command.go
@@ -9,7 +9,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setplace"
 	"github.com/WeisswurstSystems/WWM-BB/wwm"
 	"net/http"
-	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/payorder"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/toggleorderpayed"
 	"github.com/gorilla/mux"
 	"github.com/go-errors/errors"
 	"github.com/WeisswurstSystems/WWM-BB/meeting"
@@ -22,7 +22,7 @@ type Interactor interface {
 	removeproduct.RemoveProductUseCase
 	setbuyer.SetBuyerUseCase
 	setplace.SetPlaceUseCase
-	payorder.PayOrderUsecase
+	toggleorderpayed.ToggleOrderPayedUseCase
 }
 
 type CommandHandler struct {
@@ -88,8 +88,8 @@ func (ch *CommandHandler) SetPlace(w http.ResponseWriter, req *http.Request) err
 	return ch.Interactor.SetPlace(e)
 }
 
-func (ch *CommandHandler) PayOrder(w http.ResponseWriter, req *http.Request) error {
-	var e payorder.Request
+func (ch *CommandHandler) ToggleOrderPayed(w http.ResponseWriter, req *http.Request) error {
+	var e toggleorderpayed.Request
 	e.Login.Mail, e.Login.Password, _  = req.BasicAuth()
 
 	id, ok := mux.Vars(req)["meetingId"]
@@ -102,5 +102,5 @@ func (ch *CommandHandler) PayOrder(w http.ResponseWriter, req *http.Request) err
 	if err != nil {
 		return err
 	}
-	return ch.Interactor.PayOrder(e)
+	return ch.Interactor.ToggleOrderPayed(e)
 }

--- a/meeting/adapter/command/example_test.go
+++ b/meeting/adapter/command/example_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/removeproduct"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setbuyer"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setplace"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/payorder"
 )
 
 func ExampleCommandHandler_CreateMeeting() {
@@ -117,6 +118,27 @@ func ExampleCommandHandler_SetPlace() {
 	// {
 	//   "place": "",
 	//   "meetingID": "",
+	//   "login": {
+	//     "mail": "",
+	//     "password": ""
+	//   }
+	// }
+}
+
+func ExampleCommandHandler_PayOrder() {
+	// Send a json Request in this form
+	var request payorder.Request
+	data, _ := json.MarshalIndent(request, "", "  ")
+	fmt.Printf("%s", data)
+
+	// Output:
+	// {
+	//   "meetingID": "",
+	//   "order": {
+	//     "customer": "",
+	//     "payed": false,
+	//     "items": null
+	//   },
 	//   "login": {
 	//     "mail": "",
 	//     "password": ""

--- a/meeting/adapter/command/example_test.go
+++ b/meeting/adapter/command/example_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/removeproduct"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setbuyer"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setplace"
-	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/payorder"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/toggleorderpayed"
 )
 
 func ExampleCommandHandler_CreateMeeting() {
@@ -127,18 +127,14 @@ func ExampleCommandHandler_SetPlace() {
 
 func ExampleCommandHandler_PayOrder() {
 	// Send a json Request in this form
-	var request payorder.Request
+	var request toggleorderpayed.Request
 	data, _ := json.MarshalIndent(request, "", "  ")
 	fmt.Printf("%s", data)
 
 	// Output:
 	// {
 	//   "meetingID": "",
-	//   "order": {
-	//     "customer": "",
-	//     "payed": false,
-	//     "items": null
-	//   },
+	//   "customer": "",
 	//   "login": {
 	//     "mail": "",
 	//     "password": ""

--- a/meeting/adapter/command/mock_test.go
+++ b/meeting/adapter/command/mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/removeproduct"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setbuyer"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setplace"
-	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/payorder"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/toggleorderpayed"
 )
 
 type Mock struct {
@@ -18,7 +18,7 @@ type Mock struct {
 		RemoveProduct removeproduct.Request
 		SetBuyer      setbuyer.Request
 		SetPlace      setplace.Request
-		PayOrder      payorder.Request
+		ToggleOrderPayed      toggleorderpayed.Request
 	}
 }
 
@@ -59,7 +59,7 @@ func (mock *Mock) SetPlace(request setplace.Request) error {
 	return nil
 }
 
-func (mock *Mock) PayOrder(request payorder.Request) error {
-	mock.Requests.PayOrder = request
+func (mock *Mock) ToggleOrderPayed(request toggleorderpayed.Request) error {
+	mock.Requests.ToggleOrderPayed = request
 	return nil
 }

--- a/meeting/adapter/command/mock_test.go
+++ b/meeting/adapter/command/mock_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/removeproduct"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setbuyer"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setplace"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/payorder"
 )
 
 type Mock struct {
@@ -17,6 +18,7 @@ type Mock struct {
 		RemoveProduct removeproduct.Request
 		SetBuyer      setbuyer.Request
 		SetPlace      setplace.Request
+		PayOrder      payorder.Request
 	}
 }
 
@@ -54,5 +56,10 @@ func (mock *Mock) SetBuyer(request setbuyer.Request) error {
 
 func (mock *Mock) SetPlace(request setplace.Request) error {
 	mock.Requests.SetPlace = request
+	return nil
+}
+
+func (mock *Mock) PayOrder(request payorder.Request) error {
+	mock.Requests.PayOrder = request
 	return nil
 }

--- a/meeting/detailed.go
+++ b/meeting/detailed.go
@@ -23,7 +23,7 @@ type DetailedMeeting struct {
 }
 
 type DetailedOrder struct {
-	Customer   string      `json:"customer"`
+	Customer   CustomerMail      `json:"customer"`
 	Payed      bool        `json:"payed"`
 	Items      []OrderItem `json:"items"`
 	TotalPrice float64     `json:"totalPrice"`

--- a/meeting/order.go
+++ b/meeting/order.go
@@ -1,12 +1,14 @@
 package meeting
 
+type CustomerMail string
+
 type OrderItem struct {
 	ItemName ProductName `json:"itemName"`
 	Amount   int         `json:"amount"`
 }
 
 type Order struct {
-	Customer string      `json:"customer"`
+	Customer CustomerMail      `json:"customer"`
 	Payed    bool        `json:"payed"`
 	Items    []OrderItem `json:"items"`
 }

--- a/meeting/usecase/payorder/payorder.go
+++ b/meeting/usecase/payorder/payorder.go
@@ -1,0 +1,59 @@
+package payorder
+
+import (
+	"github.com/WeisswurstSystems/WWM-BB/meeting"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase"
+	"github.com/WeisswurstSystems/WWM-BB/util"
+	"github.com/WeisswurstSystems/WWM-BB/user/usecase/authenticate"
+	"github.com/WeisswurstSystems/WWM-BB/user"
+	"errors"
+	"fmt"
+)
+
+type PayOrderUsecase interface {
+	PayOrder(request Request) error
+}
+
+type Interactor struct {
+	meeting.Store
+	authenticate.AuthenticateUseCase
+}
+
+type Request struct {
+	meeting.MeetingID `json:"meetingID"`
+	Order meeting.Order `json:"order"`
+	Login user.Login  `json:"login"`
+}
+
+func (i Interactor) PayOrder(req Request) error {
+	m, err := i.FindOne(req.MeetingID)
+	if err != nil {
+		return err
+	}
+
+	u, err := i.AuthenticateUseCase.Authenticate(req.Login)
+	if err != nil {
+		return err
+	}
+
+	if !u.HasMail(m.Creator, m.Buyer) {
+		return meeting.ErrNotAllowed
+	}
+
+	index := util.IndexOf(len(m.Orders), func(i int) bool {
+		return m.Orders[i].Customer == req.Order.Customer
+	})
+
+	if index == -1 {
+		return errors.New(fmt.Sprintf("Order with customer %v not found in Meeting %v ", req.Order.Customer, m.ID))
+	}
+
+	m.Orders[index].Payed = true
+	err = i.Save(m)
+	if err != nil {
+		return err
+	}
+
+	usecase.LOG.Printf("did %v", req)
+	return nil
+}

--- a/meeting/usecase/toggleorderpayed/toggleorderpayed.go
+++ b/meeting/usecase/toggleorderpayed/toggleorderpayed.go
@@ -1,17 +1,17 @@
-package payorder
+package toggleorderpayed
 
 import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase"
 	"github.com/WeisswurstSystems/WWM-BB/util"
 	"github.com/WeisswurstSystems/WWM-BB/user/usecase/authenticate"
-	"github.com/WeisswurstSystems/WWM-BB/user"
 	"errors"
 	"fmt"
+	"github.com/WeisswurstSystems/WWM-BB/user"
 )
 
-type PayOrderUsecase interface {
-	PayOrder(request Request) error
+type ToggleOrderPayedUseCase interface {
+	ToggleOrderPayed(request Request) error
 }
 
 type Interactor struct {
@@ -21,11 +21,11 @@ type Interactor struct {
 
 type Request struct {
 	meeting.MeetingID `json:"meetingID"`
-	Order meeting.Order `json:"order"`
+	Customer meeting.CustomerMail `json:"customer"`
 	Login user.Login  `json:"login"`
 }
 
-func (i Interactor) PayOrder(req Request) error {
+func (i Interactor) ToggleOrderPayed(req Request) error {
 	m, err := i.FindOne(req.MeetingID)
 	if err != nil {
 		return err
@@ -41,14 +41,14 @@ func (i Interactor) PayOrder(req Request) error {
 	}
 
 	index := util.IndexOf(len(m.Orders), func(i int) bool {
-		return m.Orders[i].Customer == req.Order.Customer
+		return m.Orders[i].Customer == req.Customer
 	})
 
 	if index == -1 {
-		return errors.New(fmt.Sprintf("Order with customer %v not found in Meeting %v ", req.Order.Customer, m.ID))
+		return errors.New(fmt.Sprintf("Order with customer %v not found in Meeting %v ", req.Customer, m.ID))
 	}
 
-	m.Orders[index].Payed = true
+	m.Orders[index].Payed = !m.Orders[index].Payed
 	err = i.Save(m)
 	if err != nil {
 		return err

--- a/wwm/construction/meeting.go
+++ b/wwm/construction/meeting.go
@@ -10,6 +10,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/removeproduct"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setbuyer"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setplace"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/payorder"
 )
 
 var MeetingStore = driver.NewMongoStore()
@@ -21,6 +22,7 @@ var MeetingUseCases = struct {
 	removeproduct.RemoveProductUseCase
 	setbuyer.SetBuyerUseCase
 	setplace.SetPlaceUseCase
+	payorder.PayOrderUsecase
 }{
 	createmeeting.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
 	closemeeting.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
@@ -28,6 +30,7 @@ var MeetingUseCases = struct {
 	removeproduct.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
 	setbuyer.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
 	setplace.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
+	payorder.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
 }
 
 var MeetingCommand = command.CommandHandler{

--- a/wwm/construction/meeting.go
+++ b/wwm/construction/meeting.go
@@ -10,7 +10,7 @@ import (
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/removeproduct"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setbuyer"
 	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/setplace"
-	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/payorder"
+	"github.com/WeisswurstSystems/WWM-BB/meeting/usecase/toggleorderpayed"
 )
 
 var MeetingStore = driver.NewMongoStore()
@@ -22,7 +22,7 @@ var MeetingUseCases = struct {
 	removeproduct.RemoveProductUseCase
 	setbuyer.SetBuyerUseCase
 	setplace.SetPlaceUseCase
-	payorder.PayOrderUsecase
+	toggleorderpayed.ToggleOrderPayedUseCase
 }{
 	createmeeting.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
 	closemeeting.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
@@ -30,7 +30,7 @@ var MeetingUseCases = struct {
 	removeproduct.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
 	setbuyer.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
 	setplace.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
-	payorder.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
+	toggleorderpayed.Interactor{MeetingStore, UserUseCases.AuthenticateUseCase},
 }
 
 var MeetingCommand = command.CommandHandler{

--- a/wwm/construction/meeting_routing.go
+++ b/wwm/construction/meeting_routing.go
@@ -16,4 +16,8 @@ func AddMeetingRoutes(r *mux.Router) {
 	do.Handle("/removeProduct", wwm.Handler(MeetingCommand.RemoveProduct)).Methods("POST")
 	do.Handle("/setBuyer", wwm.Handler(MeetingCommand.SetBuyer)).Methods("POST")
 	do.Handle("/setPlace", wwm.Handler(MeetingCommand.SetPlace)).Methods("POST")
+	do.Handle("/payOrder", wwm.Handler(MeetingCommand.PayOrder)).Methods("POST")
+
+	doID := r.PathPrefix("/{meetingId}/do").Subrouter()
+	doID.Handle("/payOrder", wwm.Handler(MeetingCommand.PayOrder)).Methods("POST")
 }

--- a/wwm/construction/meeting_routing.go
+++ b/wwm/construction/meeting_routing.go
@@ -16,8 +16,7 @@ func AddMeetingRoutes(r *mux.Router) {
 	do.Handle("/removeProduct", wwm.Handler(MeetingCommand.RemoveProduct)).Methods("POST")
 	do.Handle("/setBuyer", wwm.Handler(MeetingCommand.SetBuyer)).Methods("POST")
 	do.Handle("/setPlace", wwm.Handler(MeetingCommand.SetPlace)).Methods("POST")
-	do.Handle("/payOrder", wwm.Handler(MeetingCommand.PayOrder)).Methods("POST")
 
 	doID := r.PathPrefix("/{meetingId}/do").Subrouter()
-	doID.Handle("/payOrder", wwm.Handler(MeetingCommand.PayOrder)).Methods("POST")
+	doID.Handle("/toggleOrderPayed", wwm.Handler(MeetingCommand.ToggleOrderPayed)).Methods("POST")
 }


### PR DESCRIPTION
## Kurzbeschreibung der Änderungen

Mit einem POST auf `/{meetingId}/do/payOrder` und einer Order im Body wird die im Body gesendete Order als bezahlt gesetzt.

## Checkliste

- [ ] Funktionalität getestet
- [x] Dokumentation im Wiki ergänzt https://github.com/WeisswurstSystems/WWM-BB/wiki/Schnittstellen#bestellung-als-bezahlt-markieren

## Referenzen

closes #14