### PR TITLE
pfade auf id in pfad umgestellt

### DIFF
--- a/wwm/construction/meeting_routing.go
+++ b/wwm/construction/meeting_routing.go
@@ -9,17 +9,18 @@ func AddMeetingRoutes(r *mux.Router) {
 	r.Handle("/", wwm.Handler(MeetingQuery.FindAll)).Methods("GET")
 	r.Handle("/{meetingId}", wwm.Handler(MeetingQuery.FindByID)).Methods("GET")
 
-	do := r.PathPrefix("/do").Subrouter()
+	// Nicht meeting-spezifische Aktionen
+	doNoID := r.PathPrefix("/do").Subrouter()
+	doNoID.Handle("/createMeeting", wwm.Handler(MeetingCommand.CreateMeeting)).Methods("POST")
+
+	// Meeting-spezifische Aktionen
+	do := r.PathPrefix("/{meetingId}/do").Subrouter()
+	do.Handle("/invite", wwm.Handler(MeetingCommand.Invite)).Methods("POST")
+	do.Handle("/notify", wwm.Handler(MeetingCommand.Notify)).Methods("POST")
+	do.Handle("/toggleOrderPayed", wwm.Handler(MeetingCommand.ToggleOrderPayed)).Methods("POST")
 	do.Handle("/closeMeeting", wwm.Handler(MeetingCommand.CloseMeeting)).Methods("POST")
-	do.Handle("/createMeeting", wwm.Handler(MeetingCommand.CreateMeeting)).Methods("POST")
 	do.Handle("/putProduct", wwm.Handler(MeetingCommand.PutProduct)).Methods("POST")
 	do.Handle("/removeProduct", wwm.Handler(MeetingCommand.RemoveProduct)).Methods("POST")
 	do.Handle("/setBuyer", wwm.Handler(MeetingCommand.SetBuyer)).Methods("POST")
 	do.Handle("/setPlace", wwm.Handler(MeetingCommand.SetPlace)).Methods("POST")
-
-	doID := r.PathPrefix("/{meetingId}/do").Subrouter()
-	doID.Handle("/invite", wwm.Handler(MeetingCommand.Invite)).Methods("POST")
-	doID.Handle("/notify", wwm.Handler(MeetingCommand.Notify)).Methods("POST")
-	doID.Handle("/toggleOrderPayed", wwm.Handler(MeetingCommand.ToggleOrderPayed)).Methods("POST")
-
 }


### PR DESCRIPTION
## Kurzbeschreibung der Änderungen

Die Meeting-Spezifischen Aktionen enthalten die Meeting-ID nun im Pfad und nicht mehr im Body. So ist es eine schöne REST-Schnittstelle

## Checkliste

- [ ] Funktionalität getestet
- [ ] Dokumentation im Wiki ergänzt (bitte hier Änderung(en) verlinken)

## Referenzen

closes #55